### PR TITLE
Add Github Actions docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,99 @@
+name: Build
+on: [push]
+
+env:
+  REGISTRY: ghcr.io
+
+
+jobs:
+  build-mqtt:
+    name: Build MQTT
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/pethublocal-mqtt
+      - uses: docker/build-push-action@v2
+        with:
+          context: docker/mqtt
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+  build-msgs:
+    name: Build msgs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/pethublocal-msgs
+      - uses: docker/build-push-action@v2
+        with:
+          context: docker/msgs
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+  build-web:
+    name: Build web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/pethublocal-web
+      - uses: docker/build-push-action@v2
+        with:
+          context: docker/web
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+  build-pethub:
+    name: Build PetHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/pethublocal-web
+      - uses: docker/build-push-action@v2
+        with:
+          context: docker/pethub
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/pethublocal-web
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/pethublocal-pethub
       - uses: docker/build-push-action@v2
         with:
           context: docker/pethub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Hey,

I've added this github action to automatically build the docker images and add them to the github package repository, so people can just pull from there rather than having to build the docker images locally - useful for me as I want to run this in kubernetes so not easy to build on the fly!

It's a bit basic, it just pushes a new latest tag when a push happens on the main branch, but it's a good starting point. It will push all 4 images to ghcr.io/plambrechtsen/pethublocal-mqtt/msgs/web/pethub)